### PR TITLE
Add devcontainer definition

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
   // "forwardPorts": [],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  // "postCreateCommand": "gcc -v",
+  "postCreateCommand": "git submodule update --init --recursive",
 
   // Configure tool-specific properties.
   // "customizations": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+  "name": "N64Recomp",
+  "image": "mcr.microsoft.com/devcontainers/cpp:1-ubuntu-22.04",
+
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  // "features": {},
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "gcc -v",
+
+  // Configure tool-specific properties.
+  // "customizations": {},
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}


### PR DESCRIPTION
Adds a config file for setting up a dev container that can compile the project. This is useful for using things like:
- Github Codespaces
- IntelliJ Dev Containers
- Visual Studio Code Dev Containers

Allows for making reproducible work environments + the possibility of building on via the web editor