### PR TITLE
Add a warning for functions with no size

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -670,7 +670,7 @@ bool read_symbols(RecompPort::Context& context, const ELFIO::elfio& elf_file, EL
         if (section_index >= context.sections.size()) {
             continue;
         }
-        
+
         // Check if this symbol is the entrypoint
         if (has_entrypoint && value == entrypoint && type == ELFIO::STT_FUNC) {
             if (found_entrypoint_func) {
@@ -729,11 +729,15 @@ bool read_symbols(RecompPort::Context& context, const ELFIO::elfio& elf_file, EL
                     }
                 }
 
+                if (!ignored && type == ELFIO::STT_FUNC && num_instructions == 0 && bind != ELFIO::STB_WEAK) {
+                    fmt::print(stderr, "[WARN] Function '{}' has zero size.\n", name);
+                }
+
                 // Suffix local symbols to prevent name conflicts.
                 if (bind == ELFIO::STB_LOCAL) {
                     name = fmt::format("{}_{:08X}", name, rom_address);
                 }
-                
+
                 if (num_instructions > 0) {
                     context.section_functions[section_index].push_back(context.functions.size());
                 }

--- a/src/recompilation.cpp
+++ b/src/recompilation.cpp
@@ -182,7 +182,7 @@ bool process_instruction(const RecompPort::Context& context, const RecompPort::C
             // FIXME: how to deal with static functions?
             if (context.functions_by_vram.find(branch_target) != context.functions_by_vram.end()) {
                 fmt::print(output_file, "{{\n    ");
-                fmt::print("Tail call in {} to 0x{:08X}\n", func.name, branch_target);
+                fmt::print("[INFO] Tail call in {} to 0x{:08X}\n", func.name, branch_target);
                 print_func_call(branch_target, false);
                 print_line("return");
                 fmt::print(output_file, ";\n    }}\n");
@@ -545,7 +545,7 @@ bool process_instruction(const RecompPort::Context& context, const RecompPort::C
             // ```
             // FIXME: how to deal with static functions?
             else if (context.functions_by_vram.find(branch_target) != context.functions_by_vram.end()) {
-                fmt::print("Tail call in {} to 0x{:08X}\n", func.name, branch_target);
+                fmt::print("[INFO] Tail call in {} to 0x{:08X}\n", func.name, branch_target);
                 print_func_call(branch_target, false);
                 print_line("return");
             }
@@ -600,13 +600,13 @@ bool process_instruction(const RecompPort::Context& context, const RecompPort::C
 
             bool is_tail_call = instr_vram == func_vram_end - 2 * sizeof(func.words[0]);
             if (is_tail_call) {
-                fmt::print("Indirect tail call in {}\n", func.name);
+                fmt::print("[INFO] Indirect tail call in {}\n", func.name);
                 print_unconditional_branch("LOOKUP_FUNC({}{})(rdram, ctx)", ctx_gpr_prefix(rs), rs);
                 print_line("return");
                 break;
             }
 
-            fmt::print(stderr, "No jump table found for jr at 0x{:08X} and not tail call\n", instr_vram);
+            fmt::print(stderr, "[WARN] No jump table found for jr at 0x{:08X} and not tail call\n", instr_vram);
         }
         break;
     case InstrId::cpu_syscall:


### PR DESCRIPTION
It can be useful to figure out problems earlier instead of having to deal with cryptic errors from the linker.

It prints a message like this.

```
[WARN] Function 'func_8007C6D8' has zero size.
```

Sadly it may catch some RSP microcodes depending on how the repo is setup
```
[WARN] Function 'gspF3DEX2_fifoTextEnd' has zero size.
Found entrypoint, original name: entrypoint
[WARN] Function 'aspMainTextStart' has zero size.
[WARN] Function 'aspMainTextEnd' has zero size.
[WARN] Function 'func_8007C6D8' has zero size.
[WARN] Function 'gspS2DEX_fifoTextEnd' has zero size.
[WARN] Function 'rspbootTextEnd' has zero size.
[WARN] Function 'gspS2DEX_fifoTextStart' has zero size.
```

A possible workaround is to add all known microcodes to the `ignored_funcs` list. I didn't include that in this PR because I didn't knew if you would like the idea, but I have no problem doing it if you like it.