### PR TITLE
Add option to output multiple functions per file, defaults to 50

### DIFF
--- a/include/recomp_port.h
+++ b/include/recomp_port.h
@@ -64,6 +64,7 @@ namespace RecompPort {
 
     struct Config {
         int32_t entrypoint;
+        int32_t functions_per_output_file;
         bool has_entrypoint;
         bool uses_mips3_float_mode;
         bool single_file_output;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -416,6 +416,17 @@ RecompPort::Config::Config(const char* path) {
             recomp_include = "#include \"librecomp/recomp.h\"";
         }
 
+        std::optional<int32_t> funcs_per_file_opt = input_data["functions_per_output_file"].value<int32_t>();
+        if (funcs_per_file_opt.has_value()) {
+            functions_per_output_file = funcs_per_file_opt.value();
+            if (functions_per_output_file <= 0) {
+                throw toml::parse_error("Invalid functions_per_output_file value", input_data["functions_per_output_file"].node()->source());
+            }
+        }
+        else {
+            functions_per_output_file = 50;
+        }
+
         // Patches section (optional)
         toml::node_view patches_data = config_data["patches"];
         if (patches_data.is_table()) {

--- a/src/recompilation.cpp
+++ b/src/recompilation.cpp
@@ -1246,7 +1246,7 @@ bool RecompPort::recompile_function(const RecompPort::Context& context, const Re
     }
 
     fmt::print(output_file,
-        "void {}(uint8_t* rdram, recomp_context* ctx) {{\n"
+        "RECOMP_FUNC void {}(uint8_t* rdram, recomp_context* ctx) {{\n"
         // these variables shouldn't need to be preserved across function boundaries, so make them local for more efficient output
         "    uint64_t hi = 0, lo = 0, result = 0;\n"
         "    unsigned int rounding_mode = DEFAULT_ROUNDING_MODE;\n"


### PR DESCRIPTION
This significantly reduces the filesystem overhead for projects, which in turns speeds up builds and improves IDE performance. This PR also adds a RECOMP_FUNC attribute to any generated functions, which is intended to be used to disable inter-procedural optimization, as it can impact the correctness of function interposition (which will be used for runtime patches).