### PR TITLE
Modding Support PR 2 (Finished mod tool base feature set and improvements for use in N64ModernRuntime)

### DIFF
--- a/OfflineModRecomp/main.cpp
+++ b/OfflineModRecomp/main.cpp
@@ -136,6 +136,9 @@ int main(int argc, const char** argv) {
 
     output_file << "#include \"mod_recomp.h\"\n\n";
 
+    // Write the API version.
+    output_file << "RECOMP_EXPORT uint32_t recomp_api_version = 1;\n\n";
+
     output_file << "// Values populated by the runtime:\n\n";
 
     // Write import function pointer array and defines (i.e. `#define testmod_inner_import imported_funcs[0]`)

--- a/OfflineModRecomp/main.cpp
+++ b/OfflineModRecomp/main.cpp
@@ -185,9 +185,14 @@ int main(int argc, const char** argv) {
     output_file << "// Array of this mod's loaded section addresses.\n";
     output_file << "RECOMP_EXPORT int32_t section_addresses[" << std::max(size_t{1}, num_sections) << "] = {0};\n\n";
 
+    // Create a set of the export indices to avoid renaming them.
+    std::unordered_set<size_t> export_indices{mod_context.exported_funcs.begin(), mod_context.exported_funcs.end()};
+
     for (size_t func_index = 0; func_index < mod_context.functions.size(); func_index++) {
         auto& func = mod_context.functions[func_index];
-        func.name = "mod_func_" + std::to_string(func_index);
+        if (!export_indices.contains(func_index)) {
+            func.name = "mod_func_" + std::to_string(func_index);
+        }
         N64Recomp::recompile_function(mod_context, func, output_file, static_funcs_by_section, true);
     }
 

--- a/OfflineModRecomp/main.cpp
+++ b/OfflineModRecomp/main.cpp
@@ -24,17 +24,9 @@ static std::vector<uint8_t> read_file(const std::filesystem::path& path, bool& f
     return ret;
 }
 
-const std::filesystem::path func_reference_syms_file_path {
-    "C:/n64/MMRecompTestMod/Zelda64RecompSyms/mm.us.rev1.syms.toml"
-};
-const std::vector<std::filesystem::path> data_reference_syms_file_paths {
-    "C:/n64/MMRecompTestMod/Zelda64RecompSyms/mm.us.rev1.datasyms.toml",
-    "C:/n64/MMRecompTestMod/Zelda64RecompSyms/mm.us.rev1.datasyms_static.toml"
-};
-
 int main(int argc, const char** argv) {
-    if (argc != 4) {
-        printf("Usage: %s [mod symbol file] [ROM] [output C file]\n", argv[0]);
+    if (argc != 5) {
+        printf("Usage: %s [mod symbol file] [mod binary file] [recomp symbols file] [output C file]\n", argv[0]);
         return EXIT_SUCCESS;
     }
     bool found;
@@ -54,7 +46,7 @@ int main(int argc, const char** argv) {
 
     std::vector<uint8_t> dummy_rom{};
     N64Recomp::Context reference_context{};
-    if (!N64Recomp::Context::from_symbol_file(func_reference_syms_file_path, std::move(dummy_rom), reference_context, false)) {
+    if (!N64Recomp::Context::from_symbol_file(argv[3], std::move(dummy_rom), reference_context, false)) {
         printf("Failed to load provided function reference symbol file\n");
         return EXIT_FAILURE;
     }
@@ -126,7 +118,7 @@ int main(int argc, const char** argv) {
     std::vector<std::vector<uint32_t>> static_funcs_by_section{};
     static_funcs_by_section.resize(mod_context.sections.size());
 
-    std::ofstream output_file { argv[3] };
+    std::ofstream output_file { argv[4] };
 
     RabbitizerConfig_Cfg.pseudos.pseudoMove = false;
     RabbitizerConfig_Cfg.pseudos.pseudoBeqz = false;

--- a/OfflineModRecomp/main.cpp
+++ b/OfflineModRecomp/main.cpp
@@ -73,11 +73,13 @@ int main(int argc, const char** argv) {
 
     N64Recomp::Context mod_context;
 
-	N64Recomp::ModSymbolsError error = N64Recomp::parse_mod_symbols(symbol_data_span, rom_data, sections_by_vrom, reference_context, mod_context);
+	N64Recomp::ModSymbolsError error = N64Recomp::parse_mod_symbols(symbol_data_span, rom_data, sections_by_vrom, mod_context);
     if (error != N64Recomp::ModSymbolsError::Good) {
         fprintf(stderr, "Error parsing mod symbols: %d\n", (int)error);
         return EXIT_FAILURE;
     }
+
+    mod_context.import_reference_context(reference_context);
 
     // Populate R_MIPS_26 reloc symbol indices. Start by building a map of vram address to matching reference symbols.
     std::unordered_map<uint32_t, std::vector<size_t>> reference_symbols_by_vram{};

--- a/OfflineModRecomp/main.cpp
+++ b/OfflineModRecomp/main.cpp
@@ -145,7 +145,8 @@ int main(int argc, const char** argv) {
         const auto& import = mod_context.import_symbols[import_index];
         output_file << "#define " << import.base.name << " imported_funcs[" << import_index << "]\n";
     }
-    output_file << "RECOMP_EXPORT recomp_func_t* imported_funcs[" << num_imports << "] = {};\n";
+
+    output_file << "RECOMP_EXPORT recomp_func_t* imported_funcs[" << std::max(size_t{1}, num_imports) << "] = {0};\n";
     output_file << "\n";
 
     // Use reloc list to write reference symbol function pointer array and defines (i.e. `#define func_80102468 reference_symbol_funcs[0]`)
@@ -160,11 +161,12 @@ int main(int argc, const char** argv) {
             }
         }
     }
-    output_file << "RECOMP_EXPORT recomp_func_t* reference_symbol_funcs[" << num_reference_symbols << "] = {};\n\n";
+    // C doesn't allow 0-sized arrays, so always add at least one member to all arrays. The actual size will be pulled from the mod symbols.
+    output_file << "RECOMP_EXPORT recomp_func_t* reference_symbol_funcs[" << std::max(size_t{1},num_reference_symbols) << "] = {0};\n\n";
 
     // Write provided event array (maps internal event indices to global ones).
     output_file << "// Mapping of internal event indices to global ones.\n";
-    output_file << "RECOMP_EXPORT uint32_t event_indices[" << mod_context.event_symbols.size() <<"] = {};\n\n";
+    output_file << "RECOMP_EXPORT uint32_t event_indices[" << std::max(size_t{1}, mod_context.event_symbols.size()) <<"] = {0};\n\n";
 
     // Write the event trigger function pointer.
     output_file << "// Pointer to the runtime function for triggering events.\n";
@@ -181,7 +183,7 @@ int main(int argc, const char** argv) {
     // Write the local section addresses pointer array.
     size_t num_sections = mod_context.sections.size();
     output_file << "// Array of this mod's loaded section addresses.\n";
-    output_file << "RECOMP_EXPORT int32_t section_addresses[" << num_sections << "] = {};\n\n";
+    output_file << "RECOMP_EXPORT int32_t section_addresses[" << std::max(size_t{1}, num_sections) << "] = {0};\n\n";
 
     for (size_t func_index = 0; func_index < mod_context.functions.size(); func_index++) {
         auto& func = mod_context.functions[func_index];

--- a/OfflineModRecomp/main.cpp
+++ b/OfflineModRecomp/main.cpp
@@ -165,8 +165,8 @@ int main(int argc, const char** argv) {
     output_file << "RECOMP_EXPORT recomp_func_t* reference_symbol_funcs[" << std::max(size_t{1},num_reference_symbols) << "] = {0};\n\n";
 
     // Write provided event array (maps internal event indices to global ones).
-    output_file << "// Mapping of internal event indices to global ones.\n";
-    output_file << "RECOMP_EXPORT uint32_t event_indices[" << std::max(size_t{1}, mod_context.event_symbols.size()) <<"] = {0};\n\n";
+    output_file << "// Base global event index for this mod's events.\n";
+    output_file << "RECOMP_EXPORT uint32_t base_event_index;\n\n";
 
     // Write the event trigger function pointer.
     output_file << "// Pointer to the runtime function for triggering events.\n";

--- a/include/n64recomp.h
+++ b/include/n64recomp.h
@@ -535,7 +535,7 @@ namespace N64Recomp {
         FunctionOutOfBounds,
     };
 
-    ModSymbolsError parse_mod_symbols(std::span<const char> data, std::span<const uint8_t> binary, const std::unordered_map<uint32_t, uint16_t>& sections_by_vrom, const Context& reference_context, Context& context_out);
+    ModSymbolsError parse_mod_symbols(std::span<const char> data, std::span<const uint8_t> binary, const std::unordered_map<uint32_t, uint16_t>& sections_by_vrom, Context& context_out);
     std::vector<uint8_t> symbols_to_bin_v1(const Context& mod_context);
 
     inline bool validate_mod_name(std::string_view str) {

--- a/include/n64recomp.h
+++ b/include/n64recomp.h
@@ -128,13 +128,6 @@ namespace N64Recomp {
     extern const std::unordered_set<std::string> ignored_funcs;
     extern const std::unordered_set<std::string> renamed_funcs;
 
-    struct Dependency {
-        uint8_t major_version;
-        uint8_t minor_version;
-        uint8_t patch_version;
-        std::string mod_id;
-    };
-
     struct ImportSymbol {
         ReferenceSymbol base;
         size_t dependency_index;
@@ -202,8 +195,6 @@ namespace N64Recomp {
         //// Mod dependencies and their symbols
         
         //// Imported values
-        // List of dependencies.
-        std::vector<Dependency> dependencies;
         // Mapping of dependency name to dependency index.
         std::unordered_map<std::string, size_t> dependencies_by_name;
         // List of symbols imported from dependencies.
@@ -235,45 +226,37 @@ namespace N64Recomp {
 
         Context() = default;
 
-        bool add_dependency(const std::string& id, uint8_t major_version, uint8_t minor_version, uint8_t patch_version) {
+        bool add_dependency(const std::string& id) {
             if (dependencies_by_name.contains(id)) {
                 return false;
             }
 
-            size_t dependency_index = dependencies.size();
-            dependencies.emplace_back(N64Recomp::Dependency {
-                .major_version = major_version,
-                .minor_version = minor_version,
-                .patch_version = patch_version,
-                .mod_id = id
-            });
+            size_t dependency_index = dependencies_by_name.size();
 
             dependencies_by_name.emplace(id, dependency_index);
-            dependency_events_by_name.resize(dependencies.size());
-            dependency_imports_by_name.resize(dependencies.size());
+            dependency_events_by_name.resize(dependencies_by_name.size());
+            dependency_imports_by_name.resize(dependencies_by_name.size());
 
             return true;
         }
 
-        bool add_dependencies(const std::vector<Dependency>& new_dependencies) {
-            dependencies.reserve(dependencies.size() + new_dependencies.size());
+        bool add_dependencies(const std::vector<std::string>& new_dependencies) {
             dependencies_by_name.reserve(dependencies_by_name.size() + new_dependencies.size());
 
             // Check if any of the dependencies already exist and fail if so.
-            for (const Dependency& dep : new_dependencies) {
-                if (dependencies_by_name.contains(dep.mod_id)) {
+            for (const std::string& dep : new_dependencies) {
+                if (dependencies_by_name.contains(dep)) {
                     return false;
                 }
             }
 
-            for (const Dependency& dep : new_dependencies) {
-                size_t dependency_index = dependencies.size();
-                dependencies.emplace_back(dep);
-                dependencies_by_name.emplace(dep.mod_id, dependency_index);
+            for (const std::string& dep : new_dependencies) {
+                size_t dependency_index = dependencies_by_name.size();
+                dependencies_by_name.emplace(dep, dependency_index);
             }
 
-            dependency_events_by_name.resize(dependencies.size());
-            dependency_imports_by_name.resize(dependencies.size());
+            dependency_events_by_name.resize(dependencies_by_name.size());
+            dependency_imports_by_name.resize(dependencies_by_name.size());
             return true;
         }
 
@@ -285,7 +268,7 @@ namespace N64Recomp {
             else {
                 // Handle special dependency names.
                 if (mod_id == DependencySelf || mod_id == DependencyBaseRecomp) {
-                    add_dependency(mod_id, 0, 0, 0);
+                    add_dependency(mod_id);
                     dependency_index = dependencies_by_name[mod_id];
                 }
                 else {
@@ -428,7 +411,7 @@ namespace N64Recomp {
         }
 
         bool find_import_symbol(const std::string& symbol_name, size_t dependency_index, SymbolReference& ref_out) const {
-            if (dependency_index >= dependencies.size()) {
+            if (dependency_index >= dependencies_by_name.size()) {
                 return false;
             }
 
@@ -476,7 +459,7 @@ namespace N64Recomp {
         }
 
         bool add_dependency_event(const std::string& event_name, size_t dependency_index, size_t& dependency_event_index) {
-            if (dependency_index >= dependencies.size()) {
+            if (dependency_index >= dependencies_by_name.size()) {
                 return false;
             }
 
@@ -547,18 +530,37 @@ namespace N64Recomp {
     ModSymbolsError parse_mod_symbols(std::span<const char> data, std::span<const uint8_t> binary, const std::unordered_map<uint32_t, uint16_t>& sections_by_vrom, Context& context_out);
     std::vector<uint8_t> symbols_to_bin_v1(const Context& mod_context);
 
-    inline bool validate_mod_name(std::string_view str) {
-        // Disallow mod names with a colon in them, since you can't specify that in a dependency string orin callbacks.
-        for (char c : str) {
-            if (c == ':') {
+    inline bool validate_mod_id(std::string_view str) {
+        // Disallow empty ids.
+        if (str.size() == 0) {
+            return false;
+        }
+
+        // Allow special dependency ids.
+        if (str == N64Recomp::DependencySelf || str == N64Recomp::DependencyBaseRecomp) {
+            return true;
+        }
+
+        // These following rules basically describe C identifiers. There's no specific reason to enforce them besides colon (currently),
+        // so this is just to prevent "weird" mod ids.
+
+        // Check the first character, which must be alphabetical or an underscore.
+        if (!isalpha(str[0]) && str[0] != '_') {
+            return false;
+        }
+
+        // Check the remaining characters, which can be alphanumeric or underscore.
+        for (char c : str.substr(1)) {
+            if (!isalnum(c) && c != '_') {
                 return false;
             }
         }
+
         return true;
     }
 
-    inline bool validate_mod_name(const std::string& str) {
-        return validate_mod_name(std::string_view{str});
+    inline bool validate_mod_id(const std::string& str) {
+        return validate_mod_id(std::string_view{str});
     }
 }
 

--- a/include/n64recomp.h
+++ b/include/n64recomp.h
@@ -70,9 +70,9 @@ namespace N64Recomp {
     constexpr std::string_view ImportSectionPrefix = ".recomp_import.";
     constexpr std::string_view CallbackSectionPrefix = ".recomp_callback.";
 
-    // Special mod names.
-    constexpr std::string_view ModSelf = ".";
-    constexpr std::string_view ModBaseRecomp = "*";
+    // Special dependency names.
+    constexpr std::string_view DependencySelf = ".";
+    constexpr std::string_view DependencyBaseRecomp = "*";
 
     struct Section {
         uint32_t rom_addr = 0;
@@ -279,10 +279,19 @@ namespace N64Recomp {
 
         bool find_dependency(const std::string& mod_id, size_t& dependency_index) {
             auto find_it = dependencies_by_name.find(mod_id);
-            if (find_it == dependencies_by_name.end()) {
-                return false;
+            if (find_it != dependencies_by_name.end()) {
+                dependency_index = find_it->second;
             }
-            dependency_index = find_it->second;
+            else {
+                // Handle special dependency names.
+                if (mod_id == DependencySelf || mod_id == DependencyBaseRecomp) {
+                    add_dependency(mod_id, 0, 0, 0);
+                    dependency_index = dependencies_by_name[mod_id];
+                }
+                else {
+                    return false;
+                }
+            }
             return true;
         }
 

--- a/src/mod_symbols.cpp
+++ b/src/mod_symbols.cpp
@@ -416,12 +416,10 @@ bool parse_v1(std::span<const char> data, const std::unordered_map<uint32_t, uin
     return offset == data.size();
 }
 
-N64Recomp::ModSymbolsError N64Recomp::parse_mod_symbols(std::span<const char> data, std::span<const uint8_t> binary, const std::unordered_map<uint32_t, uint16_t>& sections_by_vrom, const Context& reference_context, Context& mod_context_out) {
+N64Recomp::ModSymbolsError N64Recomp::parse_mod_symbols(std::span<const char> data, std::span<const uint8_t> binary, const std::unordered_map<uint32_t, uint16_t>& sections_by_vrom, Context& mod_context_out) {
     size_t offset = 0;
     mod_context_out = {};
     const FileHeader* header = reinterpret_data<FileHeader>(data, offset);
-
-    mod_context_out.import_reference_context(reference_context);
 
     if (header == nullptr) {
         return ModSymbolsError::NotASymbolFile;

--- a/src/recompilation.cpp
+++ b/src/recompilation.cpp
@@ -242,11 +242,11 @@ bool process_instruction(const N64Recomp::Context& context, const N64Recomp::Fun
         if (reloc_section == N64Recomp::SectionEvent) {
             needs_link_branch = link_branch;
             if (indent) {
-                if (!print_unconditional_branch("    recomp_trigger_event(rdram, ctx, event_indices[{}])", reloc_reference_symbol)) {
+                if (!print_unconditional_branch("    recomp_trigger_event(rdram, ctx, base_event_index + {})", reloc_reference_symbol)) {
                     return false;
                 }
             } else {
-                if (!print_unconditional_branch("recomp_trigger_event(rdram, ctx, event_indices[{}])", reloc_reference_symbol)) {
+                if (!print_unconditional_branch("recomp_trigger_event(rdram, ctx, base_event_index + {})", reloc_reference_symbol)) {
                     return false;
                 }
             }


### PR DESCRIPTION
This is the second PR for modding support in the recompiler. It makes various changes for improving the use of this repo as a component in the N64ModernRuntime repo, along with some changes to the OfflineModRecomp utility to account for those changes. This PR also finishes the base feature set of the RecompModTool utility by having it generate the final mod file instead of just the mod binary and symbol files.