### PR TITLE
Show error when zip command is not found by linux

### DIFF
--- a/RecompModTool/main.cpp
+++ b/RecompModTool/main.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <numeric>
 #include <cctype>
+#include <cstdlib>
 #include "fmt/format.h"
 #include "fmt/ostream.h"
 #include "n64recomp.h"
@@ -975,6 +976,7 @@ bool create_mod_zip(const std::filesystem::path& output_dir, const ModConfig& co
         // This is the child process, so exec zip with the arguments.
         if (execvp(arg_pointers[0], arg_pointers.data()) == -1) {
             fmt::print(stderr, "Failed to run \"zip\" ({})\n", errno);
+            exit(-1);
         }
     }
     else {

--- a/RecompModTool/main.cpp
+++ b/RecompModTool/main.cpp
@@ -973,7 +973,9 @@ bool create_mod_zip(const std::filesystem::path& output_dir, const ModConfig& co
     }
     else if (pid == 0) {
         // This is the child process, so exec zip with the arguments.
-        execvp(arg_pointers[0], arg_pointers.data());
+        if (execvp(arg_pointers[0], arg_pointers.data()) == -1) {
+            fmt::print(stderr, "Failed to run \"zip\" ({})\n", errno);
+        }
     }
     else {
         // This is the parent process, so wait for the child process to complete and check its exit code.


### PR DESCRIPTION
Make sure linux users know whether the `zip` command is found when creating a `.nrm`.