### PR TITLE
Mod function hooking

### DIFF
--- a/include/recompiler/context.h
+++ b/include/recompiler/context.h
@@ -85,6 +85,8 @@ namespace N64Recomp {
     constexpr std::string_view EventSectionName = ".recomp_event";
     constexpr std::string_view ImportSectionPrefix = ".recomp_import.";
     constexpr std::string_view CallbackSectionPrefix = ".recomp_callback.";
+    constexpr std::string_view HookSectionPrefix = ".recomp_hook.";
+    constexpr std::string_view HookReturnSectionPrefix = ".recomp_hook_return.";
 
     // Special dependency names.
     constexpr std::string_view DependencySelf = ".";
@@ -183,6 +185,19 @@ namespace N64Recomp {
         ReplacementFlags flags;
     };
 
+    enum class HookFlags : uint32_t {
+        AtReturn = 1 << 0,
+    };
+    inline HookFlags operator&(HookFlags lhs, HookFlags rhs) { return HookFlags(uint32_t(lhs) & uint32_t(rhs)); }
+    inline HookFlags operator|(HookFlags lhs, HookFlags rhs) { return HookFlags(uint32_t(lhs) | uint32_t(rhs)); }
+
+    struct FunctionHook {
+        uint32_t func_index;
+        uint32_t original_section_vrom;
+        uint32_t original_vram;
+        HookFlags flags;
+    };
+
     class Context {
     private:
         //// Reference symbols (used for populating relocations for patches)
@@ -236,6 +251,8 @@ namespace N64Recomp {
         std::vector<Callback> callbacks;
         // List of symbols from events, which contains the names of events that this context provides.
         std::vector<EventSymbol> event_symbols;
+        // List of hooks, which contains the original function to hook and the function index to call at the hook.
+        std::vector<FunctionHook> hooks;
 
         // Causes functions to print their name to the console the first time they're called.
         bool trace_mode;

--- a/include/recompiler/context.h
+++ b/include/recompiler/context.h
@@ -566,11 +566,6 @@ namespace N64Recomp {
             all_reference_sections_relocatable = true;
         }
 
-        bool is_manual_patch_symbol(uint32_t vram) const {
-            // Zero-sized symbols between 0x8F000000 and 0x90000000 are manually specified symbols for use with patches.
-            // TODO make this configurable or come up with a more sensible solution for dealing with manual symbols for patches.
-            return vram >= 0x8F000000 && vram < 0x90000000;
-        }
     };
 
     class Generator;
@@ -587,6 +582,12 @@ namespace N64Recomp {
 
     ModSymbolsError parse_mod_symbols(std::span<const char> data, std::span<const uint8_t> binary, const std::unordered_map<uint32_t, uint16_t>& sections_by_vrom, Context& context_out);
     std::vector<uint8_t> symbols_to_bin_v1(const Context& mod_context);
+    
+    inline bool is_manual_patch_symbol(uint32_t vram) {
+        // Zero-sized symbols between 0x8F000000 and 0x90000000 are manually specified symbols for use with patches.
+        // TODO make this configurable or come up with a more sensible solution for dealing with manual symbols for patches.
+        return vram >= 0x8F000000 && vram < 0x90000000;
+    }
 
     inline bool validate_mod_id(std::string_view str) {
         // Disallow empty ids.

--- a/include/recompiler/context.h
+++ b/include/recompiler/context.h
@@ -223,6 +223,8 @@ namespace N64Recomp {
         std::vector<uint8_t> rom;
         // Whether reference symbols should be validated when emitting function calls during recompilation.
         bool skip_validating_reference_symbols = true;
+        // Whether all function calls (excluding reference symbols) should go through lookup.
+        bool use_lookup_for_all_function_calls = false;
 
         //// Only used by the CLI, TODO move this to a struct in the internal headers.
         // A mapping of function name to index in the functions vector

--- a/include/recompiler/context.h
+++ b/include/recompiler/context.h
@@ -565,6 +565,12 @@ namespace N64Recomp {
         void set_all_reference_sections_relocatable() {
             all_reference_sections_relocatable = true;
         }
+
+        bool is_manual_patch_symbol(uint32_t vram) const {
+            // Zero-sized symbols between 0x8F000000 and 0x90000000 are manually specified symbols for use with patches.
+            // TODO make this configurable or come up with a more sensible solution for dealing with manual symbols for patches.
+            return vram >= 0x8F000000 && vram < 0x90000000;
+        }
     };
 
     class Generator;

--- a/include/recompiler/generator.h
+++ b/include/recompiler/generator.h
@@ -48,7 +48,7 @@ namespace N64Recomp {
         virtual void emit_case(int case_index, const std::string& target_label) const = 0;
         virtual void emit_switch_error(uint32_t instr_vram, uint32_t jtbl_vram) const = 0;
         virtual void emit_switch_close() const = 0;
-        virtual void emit_return(const Context& context) const = 0;
+        virtual void emit_return(const Context& context, size_t func_index) const = 0;
         virtual void emit_check_fr(int fpr) const = 0;
         virtual void emit_check_nan(int fpr, bool is_double) const = 0;
         virtual void emit_cop0_status_read(int reg) const = 0;
@@ -85,7 +85,7 @@ namespace N64Recomp {
         void emit_case(int case_index, const std::string& target_label) const final;
         void emit_switch_error(uint32_t instr_vram, uint32_t jtbl_vram) const final;
         void emit_switch_close() const final;
-        void emit_return(const Context& context) const final;
+        void emit_return(const Context& context, size_t func_index) const final;
         void emit_check_fr(int fpr) const final;
         void emit_check_nan(int fpr, bool is_double) const final;
         void emit_cop0_status_read(int reg) const final;

--- a/include/recompiler/live_recompiler.h
+++ b/include/recompiler/live_recompiler.h
@@ -78,6 +78,11 @@ namespace N64Recomp {
         void (*trigger_event)(uint8_t* rdram, recomp_context* ctx, uint32_t event_index);
         int32_t *reference_section_addresses;
         int32_t *local_section_addresses;
+        void (*run_hook)(uint8_t* rdram, recomp_context* ctx, size_t hook_table_index);
+        // Maps function index in recompiler context to function's entry hook slot.
+        std::unordered_map<size_t, size_t> entry_func_hooks;
+        // Maps function index in recompiler context to function's return hook slot.
+        std::unordered_map<size_t, size_t> return_func_hooks;
     };
     class LiveGenerator final : public Generator {
     public:
@@ -109,7 +114,7 @@ namespace N64Recomp {
         void emit_case(int case_index, const std::string& target_label) const final;
         void emit_switch_error(uint32_t instr_vram, uint32_t jtbl_vram) const final;
         void emit_switch_close() const final;
-        void emit_return(const Context& context) const final;
+        void emit_return(const Context& context, size_t func_index) const final;
         void emit_check_fr(int fpr) const final;
         void emit_check_nan(int fpr, bool is_double) const final;
         void emit_cop0_status_read(int reg) const final;

--- a/src/cgenerator.cpp
+++ b/src/cgenerator.cpp
@@ -301,6 +301,7 @@ void N64Recomp::CGenerator::get_operand_string(Operand operand, UnaryOpType oper
         case UnaryOpType::TruncateLFromD:
             operand_string = "TRUNC_L_D(" + operand_string + ")";
             break;
+        // TODO these four operations should use banker's rounding, but roundeven is C23 so it's unavailable here.
         case UnaryOpType::RoundWFromS:
             operand_string = "lroundf(" + operand_string + ")";
             break;

--- a/src/cgenerator.cpp
+++ b/src/cgenerator.cpp
@@ -350,7 +350,6 @@ void N64Recomp::CGenerator::get_binary_expr_string(BinaryOpType type, const Bina
     thread_local std::string input_b{};
     thread_local std::string func_string{};
     thread_local std::string infix_string{};
-    bool is_infix;
     get_operand_string(operands.operands[0], operands.operand_operations[0], ctx, input_a);
     get_operand_string(operands.operands[1], operands.operand_operations[1], ctx, input_b);
     get_notation(type, func_string, infix_string);
@@ -393,6 +392,7 @@ void N64Recomp::CGenerator::get_binary_expr_string(BinaryOpType type, const Bina
 }
 
 void N64Recomp::CGenerator::emit_function_start(const std::string& function_name, size_t func_index) const {
+    (void)func_index;
     fmt::print(output_file,
         "RECOMP_FUNC void {}(uint8_t* rdram, recomp_context* ctx) {{\n"
         // these variables shouldn't need to be preserved across function boundaries, so make them local for more efficient output
@@ -476,7 +476,8 @@ void N64Recomp::CGenerator::emit_switch_error(uint32_t instr_vram, uint32_t jtbl
     fmt::print(output_file, "default: switch_error(__func__, 0x{:08X}, 0x{:08X});\n", instr_vram, jtbl_vram);
 }
 
-void N64Recomp::CGenerator::emit_return(const Context& context) const {
+void N64Recomp::CGenerator::emit_return(const Context& context, size_t func_index) const {
+    (void)func_index;
     if (context.trace_mode) {
         fmt::print(output_file, "TRACE_RETURN()\n    ");
     }
@@ -575,7 +576,6 @@ void N64Recomp::CGenerator::process_unary_op(const UnaryOp& op, const Instructio
     // TODO these thread locals probably don't actually help right now, so figure out a better way to prevent allocations.
     thread_local std::string output{};
     thread_local std::string input{};
-    bool is_infix;
     get_operand_string(op.output, UnaryOpType::None, ctx, output);
     get_operand_string(op.input, op.operation, ctx, input);
     fmt::print(output_file, "{} = {};\n", output, input);
@@ -587,7 +587,6 @@ void N64Recomp::CGenerator::process_store_op(const StoreOp& op, const Instructio
     thread_local std::string base_str{};
     thread_local std::string imm_str{};
     thread_local std::string value_input{};
-    bool is_infix;
     get_operand_string(Operand::Base, UnaryOpType::None, ctx, base_str);
     get_operand_string(Operand::ImmS16, UnaryOpType::None, ctx, imm_str);
     get_operand_string(op.value_input, UnaryOpType::None, ctx, value_input);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -201,8 +201,8 @@ std::vector<N64Recomp::InstructionPatch> get_instruction_patches(const toml::tab
     return ret;
 }
 
-std::vector<N64Recomp::FunctionHook> get_function_hooks(const toml::table* patches_data) {
-    std::vector<N64Recomp::FunctionHook> ret;
+std::vector<N64Recomp::FunctionTextHook> get_function_hooks(const toml::table* patches_data) {
+    std::vector<N64Recomp::FunctionTextHook> ret;
 
     // Check if the function hook array exists.
     const toml::node_view func_hook_data = (*patches_data)["hook"];
@@ -230,7 +230,7 @@ std::vector<N64Recomp::FunctionHook> get_function_hooks(const toml::table* patch
                     throw toml::parse_error("before_vram is not word-aligned", el.source());
                 }
 
-                ret.push_back(N64Recomp::FunctionHook{
+                ret.push_back(N64Recomp::FunctionTextHook{
                     .func_name = func_name.value(),
                     .before_vram = before_vram.has_value() ? (int32_t)before_vram.value() : 0,
                     .text = text.value(),

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -609,7 +609,7 @@ bool N64Recomp::Context::from_symbol_file(const std::filesystem::path& symbol_fi
 
                                 RelocType reloc_type = reloc_type_from_name(type_string.value());
 
-                                if (reloc_type != RelocType::R_MIPS_HI16 && reloc_type != RelocType::R_MIPS_LO16 && reloc_type != RelocType::R_MIPS_32) {
+                                if (reloc_type != RelocType::R_MIPS_HI16 && reloc_type != RelocType::R_MIPS_LO16 && reloc_type != RelocType::R_MIPS_26 && reloc_type != RelocType::R_MIPS_32) {
                                     throw toml::parse_error("Invalid reloc entry type", reloc_el.source());
                                 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -12,7 +12,7 @@ namespace N64Recomp {
         uint32_t value;
     };
 
-    struct FunctionHook {
+    struct FunctionTextHook {
         std::string func_name;
         int32_t before_vram;
         std::string text;
@@ -57,7 +57,7 @@ namespace N64Recomp {
         std::vector<std::string> ignored_funcs;
         std::vector<std::string> renamed_funcs;
         std::vector<InstructionPatch> instruction_patches;
-        std::vector<FunctionHook> function_hooks;
+        std::vector<FunctionTextHook> function_hooks;
         std::vector<FunctionSize> manual_func_sizes;
         std::vector<ManualFunction> manual_functions;
         std::string bss_section_suffix;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -536,7 +536,7 @@ int main(int argc, char** argv) {
     }
 
     // Apply any function hooks.
-    for (const N64Recomp::FunctionHook& patch : config.function_hooks) {
+    for (const N64Recomp::FunctionTextHook& patch : config.function_hooks) {
         // Check if the specified function exists.
         auto func_find = context.functions_by_name.find(patch.func_name);
         if (func_find == context.functions_by_name.end()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -912,9 +912,11 @@ int main(int argc, char** argv) {
 
                 for (size_t func_index : section_funcs) {
                     const auto& func = context.functions[func_index];
+                    size_t func_size = func.reimplemented ? 0 : func.words.size() * sizeof(func.words[0]);
 
                     if (func.reimplemented || (!func.name.empty() && !func.ignored && func.words.size() != 0)) {
-                        fmt::print(overlay_file, "    {{ .func = {}, .offset = 0x{:08x} }},\n", func.name, func.rom - section.rom_addr);
+                        fmt::print(overlay_file, "    {{ .func = {}, .offset = 0x{:08X}, .rom_size = 0x{:08X} }},\n",
+                            func.name, func.rom - section.rom_addr, func_size);
                     }
                 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -199,7 +199,7 @@ void dump_context(const N64Recomp::Context& context, const std::unordered_map<ui
                 for (const N64Recomp::Reloc& reloc : section.relocs) {
                     if (reloc.target_section == section_index || reloc.target_section == section.bss_section_index) {
                         // TODO allow emitting MIPS32 relocs for specific sections via a toml option for TLB mapping support.
-                        if (reloc.type == N64Recomp::RelocType::R_MIPS_HI16 || reloc.type == N64Recomp::RelocType::R_MIPS_LO16) {
+                        if (reloc.type == N64Recomp::RelocType::R_MIPS_HI16 || reloc.type == N64Recomp::RelocType::R_MIPS_LO16 || reloc.type == N64Recomp::RelocType::R_MIPS_26) {
                             fmt::print(func_context_file, "    {{ type = \"{}\", vram = 0x{:08X}, target_vram = 0x{:08X} }},\n",
                                 reloc_names[static_cast<int>(reloc.type)], reloc.address, reloc.target_section_offset + section.ram_addr);
                         }

--- a/src/recompilation.cpp
+++ b/src/recompilation.cpp
@@ -46,7 +46,7 @@ JalResolutionResult resolve_jal(const N64Recomp::Context& context, size_t cur_se
 
             // Zero-sized symbol handling. unless there's only one matching target.
             if (target_func.words.empty()) {
-                if (!context.is_manual_patch_symbol(target_func.vram)) {
+                if (!N64Recomp::is_manual_patch_symbol(target_func.vram)) {
                     continue;
                 }
             }

--- a/src/recompilation.cpp
+++ b/src/recompilation.cpp
@@ -46,9 +46,7 @@ JalResolutionResult resolve_jal(const N64Recomp::Context& context, size_t cur_se
 
             // Zero-sized symbol handling. unless there's only one matching target.
             if (target_func.words.empty()) {
-                // Allow zero-sized symbols between 0x8F000000 and 0x90000000 for use with patches.
-                // TODO make this configurable or come up with a more sensible solution for dealing with manual symbols for patches.
-                if (target_func.vram < 0x8F000000 || target_func.vram > 0x90000000) {
+                if (!context.is_manual_patch_symbol(target_func.vram)) {
                     continue;
                 }
             }


### PR DESCRIPTION
This PR adds the ability for the live generator to emit a small amount of code on the entry point and return point(s) of a given function in order to allow hooking arbitrary functions in mods.

This PR also dumps additional context into the recompiler output overlay file to give recomps all the information they need to regenerate vanilla functions and functions patched by the base recomp project, which allows them to insert hooks into those as well.