### PR TITLE
Update mod tool for new manifest changes

### DIFF
--- a/include/recompiler/context.h
+++ b/include/recompiler/context.h
@@ -563,6 +563,16 @@ namespace N64Recomp {
     ModSymbolsError parse_mod_symbols(std::span<const char> data, std::span<const uint8_t> binary, const std::unordered_map<uint32_t, uint16_t>& sections_by_vrom, Context& context_out);
     std::vector<uint8_t> symbols_to_bin_v1(const Context& mod_context);
 
+    // Locale-independent ASCII-only version of isalpha.
+    inline bool isalpha_nolocale(char c) {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+    }
+    
+    // Locale-independent ASCII-only version of isalnum.
+    inline bool isalnum_nolocale(char c) {
+        return isalpha_nolocale(c) || (c >= '0' && c <= '9');
+    }
+
     inline bool validate_mod_id(std::string_view str) {
         // Disallow empty ids.
         if (str.size() == 0) {
@@ -578,13 +588,13 @@ namespace N64Recomp {
         // so this is just to prevent "weird" mod ids.
 
         // Check the first character, which must be alphabetical or an underscore.
-        if (!isalpha(str[0]) && str[0] != '_') {
+        if (!isalpha_nolocale(str[0]) && str[0] != '_') {
             return false;
         }
 
         // Check the remaining characters, which can be alphanumeric or underscore.
         for (char c : str.substr(1)) {
-            if (!isalnum(c) && c != '_') {
+            if (!isalnum_nolocale(c) && c != '_') {
                 return false;
             }
         }


### PR DESCRIPTION
The mod manifest has had a few changes, which this PR syncs up with:
* The manifest is now named mod.json instead of manifest.json
* The manifest now has a display_name field (required) and description/short_description fields (optional)

Additionally, this switches to use tomlplusplus to create the manifest json so that escaping is handled properly.